### PR TITLE
feat: add management command to update Lucide icons and support custo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,32 @@ That icon again, but with the paths changed to a narrower stroke width, and a "d
     {{ lucide("a-arrow-down", stroke_width=1, data_controller="language") }}
 ```
 
+### Use the Latest Lucide Icons (Custom Update & ZIP Selection)
+
+By default, this package uses the Lucide icon ZIP file bundled within the package.
+**You can now easily update to the latest Lucide icons at any time—without waiting for a package release.**
+
+**Updating to the Latest Icons**
+
+A management command is provided to fetch the newest icons and save them to your project’s root folder.
+
+**Usage:**
+
+```bash
+python manage.py update_lucide_icons
+```
+This will download the latest Lucide icon ZIP from GitHub and save it as lucide-latest.zip in your Django project’s root directory.
+
+## Using a Custom ZIP File (Settings Option)
+You can explicitly tell lucide which ZIP file to use by setting the following variable in your settings.py:
+```python
+import os
+LUCIDE_ICONS_ZIP_PATH = os.path.join(BASE_DIR, "lucide-latest.zip")
+```
+If this setting is provided and the file exists, lucide will always load icons from your specified ZIP file.
+
+If the file is missing or the setting is unset, lucide falls back to the built-in package ZIP.
+
 ## Acknowledgements
 
 This package is heavely inspired by [Adam Johnson's heroicons](https://github.com/adamchainz/heroicons). It's actually mostly copied from it so a huge thanks Adam!

--- a/src/lucide/management/commands/update_lucide_icons.py
+++ b/src/lucide/management/commands/update_lucide_icons.py
@@ -8,11 +8,11 @@ class Command(BaseCommand):
     help = "Download the latest Lucide icons and update the local zip file."
 
     def handle(self, *args, **options):
-        # Finde das Projekt-Root
+        # Find the root directory of the project
         root_dir = settings.BASE_DIR if hasattr(settings, "BASE_DIR") else os.getcwd()
         output_path = os.path.join(root_dir, "lucide-latest.zip")
 
-        # Hole die neueste Version von GitHub
+        # Check if the output path is writable
         import requests
         api_url = "https://api.github.com/repos/lucide-icons/lucide/releases/latest"
         r = requests.get(api_url)

--- a/src/lucide/management/commands/update_lucide_icons.py
+++ b/src/lucide/management/commands/update_lucide_icons.py
@@ -1,0 +1,44 @@
+import os
+from django.core.management.base import BaseCommand
+from django.conf import settings
+from zipfile import ZIP_DEFLATED, ZipFile
+from io import BytesIO
+
+class Command(BaseCommand):
+    help = "Download the latest Lucide icons and update the local zip file."
+
+    def handle(self, *args, **options):
+        # Finde das Projekt-Root
+        root_dir = settings.BASE_DIR if hasattr(settings, "BASE_DIR") else os.getcwd()
+        output_path = os.path.join(root_dir, "lucide-latest.zip")
+
+        # Hole die neueste Version von GitHub
+        import requests
+        api_url = "https://api.github.com/repos/lucide-icons/lucide/releases/latest"
+        r = requests.get(api_url)
+        r.raise_for_status()
+        version = r.json()["tag_name"]
+
+        self.stdout.write(self.style.SUCCESS(f"Loading Lucide icons version {version} …"))
+        zip_url = f"https://github.com/lucide-icons/lucide/releases/download/{version}/lucide-icons-{version}.zip"
+        r = requests.get(zip_url)
+        r.raise_for_status()
+        input_zip = ZipFile(BytesIO(r.content))
+        input_prefix = "icons/"
+
+        try:
+            os.remove(output_path)
+        except FileNotFoundError:
+            pass
+
+        with ZipFile(output_path, "w", compression=ZIP_DEFLATED, compresslevel=9) as output_zip:
+            for name in sorted(input_zip.namelist()):
+                if name.startswith(input_prefix) and name.endswith(".svg"):
+                    info = input_zip.getinfo(name)
+                    data = input_zip.read(name).replace(b' data-slot="icon"', b"")
+                    new_name = name[len(input_prefix):]
+                    info.filename = new_name
+                    output_zip.writestr(info, data)
+                    self.stdout.write(f"  ✓ {new_name}")
+
+        self.stdout.write(self.style.SUCCESS(f"\n✅ Newest Lucide icons loaded: {output_path}"))

--- a/tests/test_lucide.py
+++ b/tests/test_lucide.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import os
+import shutil
+import tempfile
 from xml.etree import ElementTree
 
 import pytest
+from django.test import override_settings
 
 import lucide
 
@@ -30,3 +34,35 @@ def test_load_icon_fail_unknown():
         lucide._load_icon("hoome")
 
     assert excinfo.value.args == ("The icon 'hoome' does not exist.",)
+
+
+def make_fake_zip_with_icon(icon_name: str, svg_content: str, path: str):
+    from zipfile import ZipFile
+    with ZipFile(path, "w") as z:
+        z.writestr(f"{icon_name}.svg", svg_content)
+
+
+def test_icon_loading_from_custom_zip():
+    tmp = tempfile.mkdtemp()
+    try:
+        zip_path = os.path.join(tmp, "lucide-latest.zip")
+        ICON = "testicon"
+        SVG = '<svg width="24" height="24"><path d="M0 0h24v24H0z"/></svg>'
+        make_fake_zip_with_icon(ICON, SVG, zip_path)
+
+        with override_settings(LUCIDE_ICONS_ZIP_PATH=zip_path):
+            lucide._load_icon.cache_clear()  # Clear cache for deterministic test
+            el = lucide._load_icon(ICON)
+            assert el.tag == "svg"
+            assert el.attrib["width"] == "24"
+    finally:
+        shutil.rmtree(tmp)
+
+
+def test_icon_loading_fallback():
+    # This test checks the fallback to built-in zip
+    # The default lucide tests already exercise this,
+    # but you can still explicitly call without override
+    lucide._load_icon.cache_clear()
+    el = lucide._load_icon("a-arrow-down")
+    assert el.tag == "svg"


### PR DESCRIPTION
…m ZIP file path

- Adds update_lucide_icons management command to fetch the latest icons from GitHub.
- Introduces the LUCIDE_ICONS_ZIP_PATH Django setting to override the default ZIP source for icons.
- Updates README with instructions for usage.